### PR TITLE
Add support for PKBarcodeFormatCode128 and updated test case.

### DIFF
--- a/src/main/java/com/ryantenney/passkit4j/Pass.java
+++ b/src/main/java/com/ryantenney/passkit4j/Pass.java
@@ -43,6 +43,8 @@ public class Pass {
 	// Visual Appearance Keys
 
 	private Barcode barcode;
+	private List<Barcode> barcodes;
+	
 	private Color backgroundColor;
 	private Color foregroundColor;
 	private String groupingIdentifier;
@@ -86,6 +88,20 @@ public class Pass {
 	@JsonIgnore private List<NamedInputStreamSupplier> files;
 
 
+	public List<Barcode> barcodes() {
+		return this.barcodes;
+	}
+	
+	public Pass barcodes(List<Barcode> values) {
+		this.barcodes = values;
+		return this;
+	}
+	
+	public Pass barcodes(Barcode... values) {
+		this.barcodes = Arrays.asList(values);
+		return this;
+	}
+	
 	public List<NamedInputStreamSupplier> files() {
 		if (this.files == null) {
 			return Collections.emptyList();

--- a/src/main/java/com/ryantenney/passkit4j/model/BarcodeFormat.java
+++ b/src/main/java/com/ryantenney/passkit4j/model/BarcodeFormat.java
@@ -10,7 +10,8 @@ public enum BarcodeFormat {
 
 	PDF417("PKBarcodeFormatPDF417"),
 	QR("PKBarcodeFormatQR"),
-	AZTEC("PKBarcodeFormatAztec");
+	AZTEC("PKBarcodeFormatAztec"),
+	CODE128("PKBarcodeFormatCode128");
 
 	private static final Map<String, BarcodeFormat> lookup;
 

--- a/src/test/java/com/ryantenney/passkit4j/StoreCardExample.java
+++ b/src/test/java/com/ryantenney/passkit4j/StoreCardExample.java
@@ -28,6 +28,9 @@ public class StoreCardExample {
 				new Location(43.165389, -77.589655).relevantText("Public Market")
 			)
 			.barcode(new Barcode(BarcodeFormat.PDF417, "12345678"))
+			.barcodes(
+					new Barcode(BarcodeFormat.CODE128, "12345678"),
+					new Barcode(BarcodeFormat.PDF417, "12345678"))
 			.logoText("Boulder Coffee")
 			.foregroundColor(Color.WHITE)
 			.backgroundColor(new Color(118, 74, 50))


### PR DESCRIPTION
Hi Ryan, iOS9 now has support for PKBarcodeFormatCode128.  I have made the necessary changes to the library to add this.   I have tested this on iOS9/8/7 and it works great.

The change added includes:

- new barcode format PKBarcodeFormatCode128
- new barcodes key, that is an array that takes in a dictionary of barcodes, which defines the primary barcode and a fallback. You can read more about it here:

https://developer.apple.com/library/prerelease/ios/documentation/UserExperience/Reference/PassKit_Bundle/Chapters/TopLevel.html#//apple_ref/doc/uid/TP40012026-CH2-SW1

Aside:
- I did not check-in the pom.xml file, but please be aware that I could not get delombok goal to work so I had comment it out.  This what my delombok section of the pom.xml looks like.

           <plugin/>
                  <groupId>org.projectlombok</groupId>
                  <artifactId>lombok-maven-plugin</artifactId>
                  <version>1.16.6.1</version>
<!--                   <executions> -->
<!--                     <execution> -->
<!--                       <phase>generate-sources</phase> -->
<!--                       <goals> -->
<!--                         <goal>delombok</goal> -->
<!--                       </goals> -->
<!--                     </execution> -->
<!--                   </executions> -->
<!--                   <configuration> -->
<!--                     <addOutputDirectory>false</addOutputDirectory> -->
<!--                     <sourceDirectory>src/main/java</sourceDirectory> -->
<!--                   </configuration> -->
            </plugin>
