### PR TITLE
Add the ignoresTimeZone attribute in DateField

### DIFF
--- a/src/main/java/com/ryantenney/passkit4j/model/DateField.java
+++ b/src/main/java/com/ryantenney/passkit4j/model/DateField.java
@@ -28,6 +28,7 @@ public class DateField implements Field<Date> {
 	private DateStyle dateStyle;
 	private DateStyle timeStyle;
 	@JsonProperty("isRelative") private boolean relative = false;
+	private boolean ignoresTimeZone = false;
 
 	public DateField(String key, String label, Date value) {
 		this(key, value);


### PR DESCRIPTION
Here is the PR for adding the ignoresTimeZone attribute in the DateField class, to deal with this iOS7 enhancement.