### PR TITLE
Jackson upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>0.12.0</version>
+			<version>1.16.16</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -206,7 +206,7 @@
 			<plugin>
 				<groupId>org.projectlombok</groupId>
 				<artifactId>lombok-maven-plugin</artifactId>
-				<version>0.12.0.0</version>
+				<version>1.16.16.0</version>
 				<executions>
 					<execution>
 						<phase>generate-sources</phase>
@@ -321,7 +321,7 @@
 					<plugin>
 						<groupId>org.projectlombok</groupId>
 						<artifactId>lombok-maven-plugin</artifactId>
-						<version>0.12.0.0</version>
+						<version>1.16.16.0</version>
 						<dependencies>
 							<dependency>
 								<groupId>sun.jdk</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,17 +60,17 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.1.0</version>
+			<version>2.7.4</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.1.0</version>
+			<version>2.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.1.0</version>
+			<version>2.7.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>

--- a/src/main/java/com/ryantenney/passkit4j/Pass.java
+++ b/src/main/java/com/ryantenney/passkit4j/Pass.java
@@ -23,6 +23,8 @@ import com.ryantenney.passkit4j.model.Color;
 import com.ryantenney.passkit4j.model.Location;
 import com.ryantenney.passkit4j.model.NFC;
 import com.ryantenney.passkit4j.model.PassInformation;
+import java.text.ParseException;
+import java.text.ParsePosition;
 
 @Data
 @NoArgsConstructor
@@ -177,8 +179,12 @@ public class Pass {
 	}
 
 	public Pass relevantDate(String iso8601dateString) {
-		this.relevantDate = ISO8601Utils.parse(iso8601dateString);
-		return this;
+        try {
+            this.relevantDate = ISO8601Utils.parse(iso8601dateString, new ParsePosition(0));
+            return this;
+        } catch (ParseException e) {
+            throw new IllegalArgumentException(e);
+        }
 	}
 
 	public Pass expirationDate(Date expirationDate) {
@@ -192,8 +198,12 @@ public class Pass {
 	}
 
 	public Pass expirationDate(String iso8601dateString) {
-		this.expirationDate = ISO8601Utils.parse(iso8601dateString);
-		return this;
+        try {
+            this.expirationDate = ISO8601Utils.parse(iso8601dateString, new ParsePosition(0));
+            return this;
+        } catch (ParseException e) {
+            throw new IllegalArgumentException(e);
+        }
 	}
 
 }

--- a/src/main/java/com/ryantenney/passkit4j/model/Location.java
+++ b/src/main/java/com/ryantenney/passkit4j/model/Location.java
@@ -20,7 +20,7 @@ public class Location {
 	  this.longitude = longitude;
 	}
 
-	@JsonInclude(Include.NON_DEFAULT) private double altitude = Double.NaN;
+	@JsonInclude(Include.NON_NULL) private Double altitude = null;
 	private String relevantText;
 
 }

--- a/src/main/java/com/ryantenney/passkit4j/sign/PassSignerImpl.java
+++ b/src/main/java/com/ryantenney/passkit4j/sign/PassSignerImpl.java
@@ -53,7 +53,6 @@ public class PassSignerImpl implements PassSigner {
 		/**
 		 * Deprecated in favor of calling {@code keystore(InputStream, String)}
 		 * followed by setting the alias with {@code alias(String)}
-		 * @param keyStore
 		 * @param alias
 		 * @param password
 		 * @return

--- a/src/test/java/com/ryantenney/passkit4j/EventTicketExample.java
+++ b/src/test/java/com/ryantenney/passkit4j/EventTicketExample.java
@@ -21,7 +21,7 @@ public class EventTicketExample {
 			.serialNumber("nmyuxofgnb")
 			.relevantDate("2011-12-08T13:00:00-08:00")
 			.locations(
-				new Location(37.6189722, -122.3748889),
+				new Location(37.6189722, -122.3748889).altitude(10.0),
 				new Location(37.33182, -122.03118)
 			)
 			.barcode(new Barcode(BarcodeFormat.PDF417, "123456789"))


### PR DESCRIPTION
NON_DEFAULT doesn't seem to be working in the newer version.
In the case of Location.altitude (which is optional), not setting a
value results in the field not being ignored as it appearing in the
pass.json file:

{
    "latitude" : 37.33182,
    "longitude" : -122.03118,
    "altitude" : "NaN"
}

This is not a valid format which results in the Wallet app not reading
the pass.

I changed Include.NON_DEFAULT to Include.NON_NULL and set the default
altitude value to null. This results in the same behavior as before
the upgrade of Jackson.